### PR TITLE
CRUD query's for project and subproject in employee REPO

### DIFF
--- a/src/main/java/com/example/estimatea/repository/jdbc/EmployeeRepository.java
+++ b/src/main/java/com/example/estimatea/repository/jdbc/EmployeeRepository.java
@@ -1,26 +1,56 @@
 package com.example.estimatea.repository.jdbc;
 
+import com.example.estimatea.model.Employee;
+import com.example.estimatea.model.Project;
+import com.example.estimatea.model.SubProject;
 import com.example.estimatea.repository.mapper.EmployeeMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public class EmployeeRepository {
 
     private final JdbcTemplate jdbc;
     private final EmployeeMapper employeeMapper;
 
+    // MODELS
+    private Employee employee;
+    private Project project;
+    private SubProject subProject;
+
     // SQL STATEMENTS FOR project_employee Linked to a Project
-    private final String ADD_EMPLOYEE_TO_PROJECT = "INSERT INTO project_employee_junction (employee_id, project_id) VALUES (?, ?)";
-    private final String REMOVE_EMPLOYEE_FROM_PROJECT = "DELETE FROM project_employee WHERE project_employee_id = ?";
+    private final String ADD_EMPLOYEE_TO_PROJECT = "INSERT INTO project_employee (employee_id, project_id) VALUES (?, ?)";
+    private final String REMOVE_EMPLOYEE_FROM_PROJECT = "DELETE FROM project_employee WHERE project_employee_id = ? AND project_id = ?";
 
     // SQL STATEMENTS FOR sub_project_employee Linked to a Sub-Project
     private final String ADD_EMPLOYEE_TO_SUB_PROJECT = "INSERT INTO sub_project_employee_junction (project_employee_id, sub_id) VALUES (?, ?)";
     private final String REMOVE_EMPLOYEE_FROM_SUB_PROJECT = "DELETE FROM sub_project_employee_junction WHERE project_employee_id = ? AND sub_id = ?";
 
-
-    public EmployeeRepository(JdbcTemplate jdbc) {
+    public EmployeeRepository(JdbcTemplate jdbc, EmployeeMapper employeeMapper) {
         this.jdbc = jdbc;
         this.employeeMapper = employeeMapper;
     }
+
+    // CRUD QUERY'S For Main project
+    public void setADD_EMPLOYEE_TO_PROJECT() {
+        jdbc.update(ADD_EMPLOYEE_TO_PROJECT, employee.getEmployeeId(), project.getProjectId());
+    }
+
+    public void setREMOVE_EMPLOYEE_FROM_PROJECT() {
+        jdbc.update(REMOVE_EMPLOYEE_FROM_PROJECT, employee.getEmployeeId(), project.getProjectId());
+    }
+
+    // CRUD QUERY'S For Subproject
+    public void setADD_EMPLOYEE_TO_SUB_PROJECT() {
+        jdbc.update(ADD_EMPLOYEE_TO_SUB_PROJECT, employee.getEmployeeId(), subProject.getProjectId());
+    }
+
+    public void setREMOVE_EMPLOYEE_FROM_SUB_PROJECT() {
+        jdbc.update(REMOVE_EMPLOYEE_FROM_SUB_PROJECT, employee.getEmployeeId(), subProject.getProjectId());
+    }
+
+
 
 
 

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS project(
     );
 
 -- PROJECT_EMPLOYEE (Links to Project & Junction TABLE sub_project_emloyee)
-CREATE TABLE IF NOT EXISTS project_employee_junction(
+CREATE TABLE IF NOT EXISTS project_employee(
     project_employee_id INT AUTO_INCREMENT PRIMARY KEY,
     employee_id INT,
     project_id INT,
@@ -56,9 +56,11 @@ CREATE TABLE IF NOT EXISTS subproject(
 
 -- SUBPROJECT_EMPLOYEE (Junction TABLE and has PK FK (employee_id, sub_id))
 CREATE TABLE IF NOT EXISTS sub_project_employee_junction(
-    project_employee_id INT REFERENCES project_employee(project_employee_id),
-    sub_id INT REFERENCES subproject(sub_id),
-    PRIMARY KEY (project_employee_id, sub_id)
+    project_employee_id INT,
+    sub_id INT,
+    PRIMARY KEY (project_employee_id, sub_id),
+    CONSTRAINT fk_project_employee FOREIGN KEY (project_employee_id) REFERENCES project_employee(project_employee_id) ON DELETE CASCADE,
+    CONSTRAINT fk_subproject FOREIGN KEY (sub_id) REFERENCES subproject(sub_id) ON DELETE CASCADE
     );
 
 -- TASK (Part of project & subproject (Links to Junction TABLE ressource_task))


### PR DESCRIPTION
Small change in sub-project_employee_junction table to make sure we actually create the composite key and links to both the employee and given subproject. 

Also added on delete cascade to prevent ghost records from happening. Since an employee can still be part of other project and sub projects.